### PR TITLE
Use the path variable '%{_rpmconfigdir}'.

### DIFF
--- a/perl-Pod-Simple.spec
+++ b/perl-Pod-Simple.spec
@@ -2,7 +2,7 @@
 # Conditional build:
 %bcond_without	tests	# do not perform "make test"
 #
-%include	/usr/lib/rpm/macros.perl
+%include	%{_rpmconfigdir}/macros.perl
 %define		pdir	Pod
 %define		pnam	Simple
 Summary:	Pod::Simple - framework for parsing Pod


### PR DESCRIPTION
Let the installation of RPM decide, where it looks for its config files. A 'local'ly compiled RPM puts its stuff in `/usr/local/lib/rpm` and does not look in `/usr/lib/rpm` for `%include` files. However, the path variable `%{_rpmconfigdir}` always is set appropriately.
